### PR TITLE
Fix issue #33 where max rank for a song in the Song Selection screen …

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectステータスパネル.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectステータスパネル.cs
@@ -53,7 +53,9 @@ namespace DTXMania
                             }
                             else if (CDTXMania.ConfigIni.nSkillMode == 1)
                             {
-                                this.n現在選択中の曲の最高ランク難易度毎[j][i] = (DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i]) == (int)DTXMania.CScoreIni.ERANK.S && DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i]) >= 95 ? DTXMania.CScoreIni.tランク値を計算して返す(0, cスコア.譜面情報.最大スキル[i]) : c曲リストノード.arスコア[j].譜面情報.最大ランク[i]);
+                                // Fix github.com/limyz/DTXmaniaXG/issues/33
+                                //this.n現在選択中の曲の最高ランク難易度毎[j][i] = (DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i]) == (int)DTXMania.CScoreIni.ERANK.S && DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i]) >= 95 ? DTXMania.CScoreIni.tランク値を計算して返す(0, cスコア.譜面情報.最大スキル[i]) : c曲リストノード.arスコア[j].譜面情報.最大ランク[i]);
+                                this.n現在選択中の曲の最高ランク難易度毎[j][i] = DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i]);
                             }
 
                             this.db現在選択中の曲の最高スキル値難易度毎[j][i] = c曲リストノード.arスコア[j].譜面情報.最大スキル[i];


### PR DESCRIPTION
…is incorrect and does not correspond to the max skill.
There were a few issues in file CActSelectステータスパネル.cs line 56:

- it compares a rank: `DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i])`  to a Skill value (95), which is not correct
- if the condition is true, it assigns value `DTXMania.CScoreIni.tランク値を計算して返す(0, cスコア.譜面情報.最大スキル[i])` as a max rank to display. But this is not correct, this value is the same regardless the difficulty level. The value to use is `DTXMania.CScoreIni.tランク値を計算して返す(0, c曲リストノード.arスコア[j].譜面情報.最大スキル[i])`

Fixing this line and always recalculating the rank from the song's skill value would also solve another issue, which is happening when the BestRank value from the score.ini file was wrongly set by a previous DTXMania version (original 3.62).
In CStage結果.cs  the `c曲リストノード.arスコア[j].譜面情報.最大ランク[i]` value is only updated when `this.b新記録ランク[i]` is true, which is not happening when the BestRank value from score.ini file was incorrect. This is happening to me quite often as original 3.62 was ranking too high in the Results screen. So 3.62a doesn't detect it as a higher rank and the Song Selection screen is not updated.